### PR TITLE
Fixed build arg name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN curl -fSL "${FLATBUFFERS_ARCHIVE_BASE_URL}/${FLATBUFFERS_ARCHIVE_TAG}" -o fl
 
 # Same build environment as FlatBuffer
 
-ARG FLATCC_ARCHIVE_BASE_URL="https://api.github.com/repos/dvidelabs/flatcc/tarball/"
+ARG FLATCC_ARCHIVE_BASE_URL="https://api.github.com/repos/dvidelabs/flatcc/tarball"
 ARG FLATCC_ARCHIVE_TAG="master"
 
 RUN curl -fSL "${FLATCC_ARCHIVE_BASE_URL}/${FLATCC_ARCHIVE_TAG}" -o flatcc.tar.gz \
@@ -127,7 +127,7 @@ ARG FLATBUFFERS_USE_CLANG="false"
 ARG FLATBUFFERS_ARCHIVE_BASE_URL="https://api.github.com/repos/google/flatbuffers/tarball"
 ARG FLATBUFFERS_ARCHIVE_TAG="master"
 ARG FLATBUFFERS_BUILD_TYPE="Release"
-ARG FLATCC_ARCHIVE_BASE_URL="https://api.github.com/repos/dvidelabs/flatcc/tarball/"
+ARG FLATCC_ARCHIVE_BASE_URL="https://api.github.com/repos/dvidelabs/flatcc/tarball"
 ARG FLATCC_ARCHIVE_TAG="master"
 
 LABEL maintainer="Evan Wies <evan@neomantra.net>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG FLATBUFFERS_IMAGE_BASE="debian"
 ARG FLATBUFFERS_IMAGE_TAG="bullseye-slim"
 
 ARG FLATBUFFERS_ARCHIVE_BASE_URL="https://api.github.com/repos/google/flatbuffers/tarball"
-ARG FLATBUFFERS_REPO_TAG="master"
+ARG FLATBUFFERS_ARCHIVE_TAG="master"
 ARG FLATBUFFERS_BUILD_TYPE="Release"
 
 # Set to exactly "true" to use clang


### PR DESCRIPTION
I am trying this Dockerfile to use flatbuffers. There were a few things wrong with it, so I fixed them.

1. fixed an unused `ARG`.
2. removed trailing slash in URL (because slash is included in request URL creation)